### PR TITLE
Add `/version` endpoint

### DIFF
--- a/api/build.rs
+++ b/api/build.rs
@@ -17,10 +17,10 @@ fn main() {
         .map(|desc| desc.trim().to_string())
         .unwrap_or_else(|| "unknown".to_string());
 
-    println!("cargo:rustc-env=GIT_COMMIT={}", git_hash);
-    println!("cargo:rustc-env=GIT_TAG={}", git_tag);
+    println!("cargo::rustc-env=GIT_COMMIT={}", git_hash);
+    println!("cargo::rustc-env=GIT_TAG={}", git_tag);
 
     // Always rerun if any git changes occur
-    println!("cargo:rerun-if-changed=.git/HEAD");
-    println!("cargo:rerun-if-changed=.git/refs/");
+    println!("cargo::rerun-if-changed=.git/HEAD");
+    println!("cargo::rerun-if-changed=.git/refs/");
 }

--- a/api/build.rs
+++ b/api/build.rs
@@ -9,7 +9,7 @@ fn main() {
         .map(|hash| hash.trim().to_string())
         .unwrap_or_else(|| "unknown".to_string());
 
-    let git_version = Command::new("git")
+    let git_tag = Command::new("git")
         .args(["describe", "--tags", "--always"])
         .output()
         .ok()
@@ -18,7 +18,7 @@ fn main() {
         .unwrap_or_else(|| "unknown".to_string());
 
     println!("cargo:rustc-env=GIT_COMMIT={}", git_hash);
-    println!("cargo:rustc-env=GIT_VERSION={}", git_version);
+    println!("cargo:rustc-env=GIT_TAG={}", git_tag);
 
     // Always rerun if any git changes occur
     println!("cargo:rerun-if-changed=.git/HEAD");

--- a/api/build.rs
+++ b/api/build.rs
@@ -1,0 +1,26 @@
+use std::process::Command;
+
+fn main() {
+    let git_hash = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|hash| hash.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let git_version = Command::new("git")
+        .args(&["describe", "--tags", "--always"])
+        .output()
+        .ok()
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|desc| desc.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_COMMIT={}", git_hash);
+    println!("cargo:rustc-env=GIT_VERSION={}", git_version);
+
+    // Always rerun if any git changes occur
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/");
+}

--- a/api/build.rs
+++ b/api/build.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 fn main() {
     let git_hash = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
+        .args(["rev-parse", "HEAD"])
         .output()
         .ok()
         .and_then(|output| String::from_utf8(output.stdout).ok())
@@ -10,7 +10,7 @@ fn main() {
         .unwrap_or_else(|| "unknown".to_string());
 
     let git_version = Command::new("git")
-        .args(&["describe", "--tags", "--always"])
+        .args(["describe", "--tags", "--always"])
         .output()
         .ok()
         .and_then(|output| String::from_utf8(output.stdout).ok())

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -34,6 +34,16 @@ async fn health() -> Json<serde_json::Value> {
     }))
 }
 
+async fn version() -> Json<serde_json::Value> {
+    Json(serde_json::json!({
+        "version": env!("CARGO_PKG_VERSION"),
+        "git": {
+            "version": env!("GIT_VERSION"),
+            "commit": env!("GIT_COMMIT"),
+        },
+    }))
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     set_log_level();
@@ -64,6 +74,7 @@ async fn main() -> anyhow::Result<()> {
         //     get(ws::<Arc<Schema>>(ConnectionConfig::new(()))),
         // )
         .route("/health", get(health))
+        .route("/version", get(version))
         .route("/graphiql", get(graphiql("/graphql", "/subscriptions")))
         .route("/playground", get(playground("/graphql", "/subscriptions")))
         .route("/", get(homepage))

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -38,7 +38,7 @@ async fn version() -> Json<serde_json::Value> {
     Json(serde_json::json!({
         "version": env!("CARGO_PKG_VERSION"),
         "git": {
-            "version": env!("GIT_VERSION"),
+            "tag": env!("GIT_TAG"),
             "commit": env!("GIT_COMMIT"),
         },
     }))


### PR DESCRIPTION
Adds `/version` endpoint to API service, i.e. 
```
{
  "git": {
    "commit": "6263dd761b254e3e93ac1845c55c72b9ee74c86b",
    "tag": "v0.4.1-1-g6263dd7"
  },
  "version": "0.1.0"
}
```