### PR TITLE
Add docker images publishing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           fetch-depth: 0  # Needed for git describe
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -56,6 +59,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           target: sink
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta-sink.outputs.tags }}
           labels: ${{ steps.meta-sink.outputs.labels }}
@@ -68,6 +72,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           target: api
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta-api.outputs.tags }}
           labels: ${{ steps.meta-api.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,9 +22,6 @@ jobs:
         with:
           fetch-depth: 0  # Needed for git describe
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -59,7 +56,6 @@ jobs:
           context: .
           file: docker/Dockerfile
           target: sink
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta-sink.outputs.tags }}
           labels: ${{ steps.meta-sink.outputs.labels }}
@@ -72,7 +68,6 @@ jobs:
           context: .
           file: docker/Dockerfile
           target: api
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta-api.outputs.tags }}
           labels: ${{ steps.meta-api.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,75 @@
+name: Build and Publish Docker images
+
+on:
+  push:
+    branches: [ "docker" ]
+
+env:
+  REGISTRY: ghcr.io
+  SINK_IMAGE_NAME: ${{ github.repository }}-sink
+  API_IMAGE_NAME: ${{ github.repository }}-api
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Needed for git describe
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Sink
+        id: meta-sink
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.SINK_IMAGE_NAME }}
+          tags: |
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Extract metadata (tags, labels) for API
+        id: meta-api
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}
+          tags: |
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Sink image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: sink
+          push: true
+          tags: ${{ steps.meta-sink.outputs.tags }}
+          labels: ${{ steps.meta-sink.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push API image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: api
+          push: true
+          tags: ${{ steps.meta-api.outputs.tags }}
+          labels: ${{ steps.meta-api.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,8 @@
 name: Build and Publish Docker images
 
 on:
-  push:
-    branches: [ "docker" ]
+  release:
+    types: [published]
 
 env:
   REGISTRY: ghcr.io
@@ -35,8 +35,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.SINK_IMAGE_NAME }}
           tags: |
-            type=sha,format=long
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=raw,value=latest
 
       - name: Extract metadata (tags, labels) for API
         id: meta-api
@@ -44,8 +44,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}
           tags: |
-            type=sha,format=long
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=raw,value=latest
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Adds a github action that publishes api and sink images to the ghcr.io registry on every release.